### PR TITLE
Fix `keepSpecialComments` option processing

### DIFF
--- a/lib/parse-options.js
+++ b/lib/parse-options.js
@@ -3,7 +3,7 @@
 module.exports = function(options) {
     if (typeof options === "string") {
         var cleanOptionArgs = options.split(" ");
-        options = {};
+        options = { level: {} };
 
         for (var i = 0; i < cleanOptionArgs.length; i++) {
             var argSplit = cleanOptionArgs[i].split("="),
@@ -15,17 +15,17 @@ module.exports = function(options) {
                     options.keepBreaks = true;
                     break;
                 case "s0":
-                    options.keepSpecialComments = 0;
+                    options.level[1] = { specialComments: 0 }
                     break;
                 case "s1":
-                    options.keepSpecialComments = 1;
+                    options.level[1] = { specialComments: 1 }
                     break;
                 case "keepSpecialComments":
                     var specialCommentOption = argSplit[1];
                     if (specialCommentOption !== "*") {
                         specialCommentOption = Number(specialCommentOption);
                     }
-                    options.keepSpecialComments = specialCommentOption;
+                    options.level[1] = { specialComments: specialCommentOption }                    
                     break;
                 // for compatibility - does nothing
                 case "skip-advanced":


### PR DESCRIPTION
The `s0`, `s1` or `keepSpecialComments` plugin options don't currently work due to a change in the structure of the CleanCSS options object.

Since 4.0 of clean-css the `keepSpecialComments` option is called `specialComments` (see ["4.0 breaking changes"](https://github.com/clean-css/clean-css#important-40-breaking-changes)) and is nested within the Level 1 optimisations options ([see example](https://github.com/clean-css/clean-css#level-1-optimizations))